### PR TITLE
Use segment-docasaurus package instead of script

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,12 @@ module.exports = {
   favicon: 'img/favicon.png',
   organizationName: 'snaplet', // Usually your GitHub org/user name.
   projectName: 'docs', // Usually your repo name.
+  plugins: ['docusaurus-plugin-segment'],
   themeConfig: {
+    segment: {
+      apiKey: 'Acdn4JWGFWlZG9UAcTcbEaa8LuG17oMY',
+      // Add other options here.
+    },
     hideableSidebar: false,
     navbar: {
       title: 'Snaplet Documentation',

--- a/index.html
+++ b/index.html
@@ -3,12 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>Snaplet Documentation</title>
-  <script>
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="iw8CaHjdOggRKJCAboVeyNOPxJeMsRq7";;analytics.SNIPPET_VERSION="4.15.3";
-      analytics.load("iw8CaHjdOggRKJCAboVeyNOPxJeMsRq7");
-      analytics.page();
-    }}();
-  </script>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Snaplet copies a production database, transforming personal information so that developers can safely code against actual data.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-segment": "^1.0.3",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",


### PR DESCRIPTION
I would like your input on this. Noticed that the docs are not picking up analytics. Spent a while trying to figure out why the script tag isn't being picked up. It's a tad strange behaviour because the same script is working on the website `snaplet.dev`. 

I found a `segment-docasaurus` package and tested it out using a custom domain on `ngrok` and it picked up the analytics. You'll see in the code that this implementation does not use the script, but rather the `docusaurus.config.js`, with an added plugin inside the config. I am not entirely sure how comfortable you are with this implementation. Let me know what you think. 