### PR TITLE
Fixes deprecated commands

### DIFF
--- a/docs/06-tutorials/github-actions.md
+++ b/docs/06-tutorials/github-actions.md
@@ -37,12 +37,12 @@ jobs:
         env:
           SNAPLET_DATABASE_URL: ${{ secrets.SNAPLET_DATA_TARGET_DB_URL }}
           SNAPLET_ACCESS_TOKEN: ${{ secrets.SNAPLET_ACCESS_TOKEN }}
-          # SNAPLET_DATABASE_ID: "Use if `.snaplet/config.json` isn't setup."
+          # SNAPLET_PROJECT_ID: "Use if `.snaplet/config.json` isn't setup."
 ```
 
 This workflow runs every morning at 4am, and can also be [manually triggered](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow)
 
-It checks out the repository, in order to access the `SNAPLET_DATABASE_ID` from `.snaplet/config.json`, then it installs the Snaplet CLI and runs the `snaplet snapshot create` command.
+It checks out the repository, in order to access the `projectId` from `.snaplet/config.json`, then it installs the Snaplet CLI and runs the `snaplet snapshot create` command.
 
 :::tip
 Use `snaplet snapshot restore -y` instead to restore the last captured snapshot rather than creating a new one.

--- a/docs/06-tutorials/github-actions.md
+++ b/docs/06-tutorials/github-actions.md
@@ -33,7 +33,7 @@ jobs:
       - name: Install Snaplet CLI
         run: curl -sL https://app.snaplet.dev/get-cli/ | bash
       - name: Restore Snapshot
-        run: snaplet snapshot create
+        run: snaplet snapshot create -y
         env:
           SNAPLET_DATABASE_URL: ${{ secrets.SNAPLET_DATA_TARGET_DB_URL }}
           SNAPLET_ACCESS_TOKEN: ${{ secrets.SNAPLET_ACCESS_TOKEN }}
@@ -45,7 +45,7 @@ This workflow runs every morning at 4am, and can also be [manually triggered](ht
 It checks out the repository, in order to access the `SNAPLET_DATABASE_ID` from `.snaplet/config.json`, then it installs the Snaplet CLI and runs the `snaplet snapshot create` command.
 
 :::tip
-Use `snaplet snapshot restore` instead to restore the last captured snapshot rather than creating a new one.
+Use `snaplet snapshot restore -y` instead to restore the last captured snapshot rather than creating a new one.
 :::
 
 ## Adding Secrets to GitHub

--- a/docs/06-tutorials/github-actions.md
+++ b/docs/06-tutorials/github-actions.md
@@ -33,19 +33,19 @@ jobs:
       - name: Install Snaplet CLI
         run: curl -sL https://app.snaplet.dev/get-cli/ | bash
       - name: Restore Snapshot
-        run: snaplet restore --new
+        run: snaplet snapshot create
         env:
-          SNAPLET_DATA_TARGET_DB_URL: ${{ secrets.SNAPLET_DATA_TARGET_DB_URL }}
+          SNAPLET_DATABASE_URL: ${{ secrets.SNAPLET_DATA_TARGET_DB_URL }}
           SNAPLET_ACCESS_TOKEN: ${{ secrets.SNAPLET_ACCESS_TOKEN }}
           # SNAPLET_DATABASE_ID: "Use if `.snaplet/config.json` isn't setup."
 ```
 
 This workflow runs every morning at 4am, and can also be [manually triggered](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow)
 
-It checks out the repository, in order to access the `SNAPLET_DATABASE_ID` from `.snaplet/config.json`, then it installs the Snaplet CLI and runs the `snaplet restore --new` command.
+It checks out the repository, in order to access the `SNAPLET_DATABASE_ID` from `.snaplet/config.json`, then it installs the Snaplet CLI and runs the `snaplet snapshot create` command.
 
 :::tip
-Remove the `--new` flag from the `snaplet restore` command to restore the last captured snapshot rather than creating a new one.
+Use `snaplet snapshot restore` instead to restore the last captured snapshot rather than creating a new one.
 :::
 
 ## Adding Secrets to GitHub


### PR DESCRIPTION
- Using `SNAPLET_DATA_TARGET_DB_URL` instead of `SNAPLET_DATABASE_URL` will not override the databaseUrl if it a local one set in `.snaplet/config`
- `snaplet restore --new` is deprecated
- `snaplet restore` moved to `snaplet snapshot restore`