### PR TITLE
feat(algolia): automate doc search index scrapping

### DIFF
--- a/.github/workflows/algolia.yaml
+++ b/.github/workflows/algolia.yaml
@@ -1,0 +1,17 @@
+name: Algolia DocSearch Scraper
+
+on:
+  schedule:
+    - scrap: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  scrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: darrenjennings/algolia-docsearch-action@master
+        with:
+          algolia_application_id: PPVJZD9QQI
+          algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
+          file: algolia.config.json

--- a/.github/workflows/algolia.yaml
+++ b/.github/workflows/algolia.yaml
@@ -2,11 +2,11 @@ name: Algolia DocSearch Scraper
 
 on:
   schedule:
-    - scrap: "0 3 * * *"
+    - cron: "0 3 * * *"
   workflow_dispatch:
 
 jobs:
-  scrap:
+  cron:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 yarn.lock
 package-lock.json
+
+# Env
+.env

--- a/algolia.config.json
+++ b/algolia.config.json
@@ -1,0 +1,42 @@
+{
+  "index_name": "snaplet-docs",
+  "start_urls": [
+    "https://docs.snaplet.dev"
+  ],
+  "sitemap_urls": [
+    "https://docs.snaplet.dev/sitemap.xml"
+  ],
+  "sitemap_alternate_links": true,
+  "selectors": {
+    "lvl0": {
+      "selector": "//li[contains(@class,'theme-doc-sidebar-item-category-level-1')]//div[contains(@class, 'menu__list-item-collapsible')]//a[contains(@class, 'menu__link--active')]/text()",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Docs"
+    },
+    "lvl1": "article h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
+  },
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.21",
-    "@docusaurus/preset-classic": "^2.0.0-beta.21",
+    "@docusaurus/core": "^2.0.1",
+    "@docusaurus/preset-classic": "^2.0.1",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",


### PR DESCRIPTION
I bumped docusaurus to the v2 stable release.

I added a workflow that we can trigger manually and which will be triggered via cron each day at 3 am to update our Algolia index.