### PR TITLE
Update prisma-seed.md - "snaplet restore" is deprecated.

### DIFF
--- a/docs/06-tutorials/prisma-seed.md
+++ b/docs/06-tutorials/prisma-seed.md
@@ -11,7 +11,7 @@ If you don't want to run two commands, you can automatically seed the database w
 
 ```bash
 "prisma": {
-  "seed": "snaplet restore --data-only --no-backup"
+  "seed": "snaplet snapshot restore --data-only --latest --yes"
 }
 ```
 

--- a/docs/06-tutorials/prisma-seed.md
+++ b/docs/06-tutorials/prisma-seed.md
@@ -11,7 +11,7 @@ If you don't want to run two commands, you can automatically seed the database w
 
 ```bash
 "prisma": {
-  "seed": "snaplet snapshot restore --data-only --latest --yes"
+  "seed": "yarn snaplet snapshot restore -y"
 }
 ```
 

--- a/docs/06-tutorials/prisma-seed.md
+++ b/docs/06-tutorials/prisma-seed.md
@@ -11,7 +11,7 @@ If you don't want to run two commands, you can automatically seed the database w
 
 ```bash
 "prisma": {
-  "seed": "yarn snaplet snapshot restore -y"
+  "seed": "snaplet snapshot restore -y"
 }
 ```
 


### PR DESCRIPTION
Updated the seed command for the new one in the doc

> ERROR: "snaplet restore" is deprecated.
> Please use "snaplet snapshot restore" (snaplet ss r) instead.

It takes the latest snapshot and say yes to all, since we cannot interact with the CLI during the seed process.