### PR TITLE
Use posthog in our docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
@@ -12,7 +14,20 @@ module.exports = {
   favicon: 'img/favicon.png',
   organizationName: 'snaplet', // Usually your GitHub org/user name.
   projectName: 'docs', // Usually your repo name.
-  plugins: ['docusaurus-plugin-segment'],
+  plugins: [
+    'docusaurus-plugin-segment',
+    [
+      path.resolve(__dirname, './plugins/posthog/index.js'),
+      {
+        apiKey: 'phc_F2nspobfCOFDskuwSN7syqKyz8aAzRTw2MEsRvQSB5G',
+        appUrl: 'https://app.posthog.com',
+        enableInDevelopment: false,
+        loaded: function (posthog) {
+          posthog.register({ source: 'docs' });
+        }.toString(),
+      },
+    ],
+  ],
   themeConfig: {
     algolia: {
       appId: 'PPVJZD9QQI',
@@ -98,8 +113,7 @@ module.exports = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/snaplet/docs/tree/main',
+          editUrl: 'https://github.com/snaplet/docs/tree/main',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -107,5 +121,4 @@ module.exports = {
       },
     ],
   ],
-  scripts: [{ src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'snaplet.dev' }],
 };

--- a/plugins/posthog/index.js
+++ b/plugins/posthog/index.js
@@ -1,0 +1,66 @@
+const path = require('path');
+
+module.exports = function (context, options) {
+  if (!options.apiKey) {
+    throw new Error(
+      `You need to specify an 'apiKey' to use posthog-docusaurus`
+    );
+  }
+
+  const {
+    apiKey,
+    appUrl = 'https://app.posthog.com',
+    enableInDevelopment = false,
+    loaded = function () {}.toString(),
+    ...rest
+  } = options;
+
+  if (!apiKey) {
+    throw new Error(
+      'You specified the `posthog` object in `themeConfig` but the `apiKey` field was missing. ' +
+        'Please ensure this is not a mistake.'
+    );
+  }
+
+  const posthogEnabled =
+    process.env.NODE_ENV === 'production' || enableInDevelopment;
+
+  return {
+    name: 'posthog',
+
+    getClientModules() {
+      return posthogEnabled ? [path.resolve(__dirname, './posthog')] : [];
+    },
+
+    injectHtmlTags() {
+      if (!posthogEnabled) {
+        return {};
+      }
+
+      const posthogInitOptions = { api_host: appUrl, ...rest };
+
+      const options = `Object.assign(${JSON.stringify(
+        posthogInitOptions
+      )},{loaded:${loaded}})`;
+
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: appUrl,
+            },
+          },
+          {
+            tagName: 'script',
+            innerHTML: `
+              !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+              posthog.init(${JSON.stringify(apiKey)},${options});
+            `,
+          },
+        ],
+      };
+    },
+  };
+};

--- a/plugins/posthog/posthog.js
+++ b/plugins/posthog/posthog.js
@@ -1,0 +1,13 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+export default (function () {
+  if (!ExecutionEnvironment.canUseDOM) {
+    return null;
+  }
+
+  return {
+    onRouteUpdate() {
+      window.posthog.capture('$pageview');
+    },
+  };
+})();

--- a/plugins/posthog/readme.md
+++ b/plugins/posthog/readme.md
@@ -1,0 +1,1 @@
+context(justinvdm, 25 May 2023): This is mostly a copy of the official posthog docusaurus plugin: https://github.com/PostHog/posthog-docusaurus. We needed to be able to provide a `loaded()` callback, which is not currently possible through this plugin.


### PR DESCRIPTION
The idea is to use posthog for analytics of our docs, but for it to be sent to the same posthog project as the rest of snaplet production (web, cli, www). In order to tell that the events came from the docs, I added `source: 'docs'` as a [super property](https://posthog.com/docs/libraries/js#super-properties).

I initially tried using the official [posthog-docusaurus integration plugin](https://github.com/PostHog/posthog-docusaurus). Problem is, this didn't give us a way to set up that `source: 'docs'` super property, so I copied the source, and modified it a little so that we can do this. We can fork the repo and send the change upstream if we think that is worth doing though.

I tested that it works by doing a `yarn build && yarn serve`.