### PR TITLE
fix: addresses broken link on AWS RDS page

### DIFF
--- a/docs/06-tutorials/aws-rds.md
+++ b/docs/06-tutorials/aws-rds.md
@@ -25,7 +25,7 @@ To allow access to your AWS RDS PostgreSQL database, you need to configure the a
 
 ## Step 2: Add a read-only role
 
-Add a read-only role by following our [PostgreSQL guide here.](guides/postgresql#create-a-read-only-role)
+Add a read-only role by following our [PostgreSQL guide here.](/guides/postgresql#create-a-read-only-role)
 
 
 ## Conclusion


### PR DESCRIPTION
## Info

* Not including the fronting slash caused the URL to appended with a `/tutorials/` prefix, which broke the link. I believe this should fix that. 
* Fixes #167 