### PR TITLE
fix: exclude docs

### DIFF
--- a/docs/04-references/data-operations/03-exclude.md
+++ b/docs/04-references/data-operations/03-exclude.md
@@ -2,26 +2,58 @@
 
 Databases often have tables that contain loads of machine generated data, like logs, that aren't really helpful during development.
 Since the code doesn't operate against this data, it can be safely excluded.
-Associating a `false` value to a table will prevent Snaplet from copying data.
-Snaplet will still create the table's structure but skip the data.
+
+
+### Excluding tables and schema:
+
+Associating a `false` value to a table will exclude it from the capture process:
 
 ```typescript
 import { defineConfig } from "snaplet";
+
 export default defineConfig({
   select: {
-    public: false
+    private: false, // Exclude the entire schema from the capture
+    public: {
+      EventLogs: false, // Exclude the EventLogs table from the capture
+    },
   },
 });
 ```
 
-You can also exclude specific tables from the capture process:
+### structure
+You can also leverage the `structure` keyword to skip dumping data but still dump the sturcture of the table (columns, indexes, etc):
+
 ```typescript
 import { defineConfig } from "snaplet";
+
 export default defineConfig({
   select: {
+    private: 'structure', // Dump the structure (with all tables) but not the data
     public: {
-      EventLogs: false,
+      EventLogs: 'structure', // Dump EventLogs structure but not the data (restore an empty table)
     },
+  },
+});
+```
+
+### $default
+
+Sometimes, it might be inconvenient to list all the tables you want to exclude. In this case, you can use the `$default` keyword to
+set the "default" behaviour, and then include the ones you want to keep:
+
+```typescript
+import { defineConfig } from "snaplet";
+
+export default defineConfig({
+  select: {
+    $default: 'structure', // Set the all the tables and schema to be dumped as structure only
+    private: false, // Except for the private schema which will be completly excluded
+    public: {
+      $default: true, // Set all the tables in the public schema to be dumped as data
+      EventLogs: 'structure', // Except for the EventLogs table for wich we only want the structure
+      Logs: false, // And the Logs table which we want to exclude completly
+    }
   },
 });
 ```


### PR DESCRIPTION
Enhanced table and schema exclusion for Snaplet

This commit included an improvement to Snaplet's data capturing process for database tables. It offers more granularity in excluding tables from data capture or only capturing structure. Additional keywords for enhanced control were also introduced.

Changes:
- Replaced association of 'false' to a table with a more explicit capture process excluding mechanism.
- Introduced `structure` keyword to capture only the structure, skipping data during the dump.
- The `$default` keyword was also introduced, which allows setting a "default" behavior for all tables, while excluding or including specific ones.
- Overall, this provides control over entire schemas, selective tables or setting default behaviors for all tables within a schema.

Fixes  S-1432 